### PR TITLE
修复函数名拼写错误

### DIFF
--- a/matching-game/CGameLogic.cpp
+++ b/matching-game/CGameLogic.cpp
@@ -197,7 +197,7 @@ bool CGameLogic::SearchPath(CGraph &graph, int nV0, int nV1)
 	// 遍历图中nV0行，从0列到nVexnum列，值为true的点
 	for (int nVi = 0; nVi < nVexnum; nVi++)
 	{
-		if (graph.GetArc(nV0, nVi) && !IsExsit(nVi))
+		if (graph.GetArc(nV0, nVi) && !IsExist(nVi))
 		{
 			// 压入当前顶点，假设为路径的一个有效顶点
 			PushVertex(nVi);
@@ -235,7 +235,7 @@ bool CGameLogic::SearchPath(CGraph &graph, int nV0, int nV1)
 }
 
 // 判断顶点是否已在路径中存在
-bool CGameLogic::IsExsit(int nVi)
+bool CGameLogic::IsExist(int nVi)
 {
 	for (int i = 0; i < m_nVexNum; i++)
 	{

--- a/matching-game/CGameLogic.h
+++ b/matching-game/CGameLogic.h
@@ -19,7 +19,7 @@ public:
 	bool IsLink(CGraph &g, Vertex v1, Vertex v2);  // 判断顶点v1与v2是否连通
 	void Clear(CGraph &g, Vertex v1, Vertex v2);   // 当V1与v2连通时，将其顶点的值设为空
 	bool SearchPath(CGraph &g, int nV0, int nV1);  // 采用深度优先搜索，判断V1在图g中是否连通
-	bool IsExsit(int nVi);						   // 判断索引为nVi的顶点是否保存到连通数组m_anPath中
+	bool IsExist(int nVi);						   // 判断索引为nVi的顶点是否保存到连通数组m_anPath中
 	bool IsCorner(void);						   // 判断连接路径数组中，连续三个顶点是否构成一个拐点
 	void PushVertex(int nV);
 	void PopVertex();


### PR DESCRIPTION
在 `CGameLogic.cpp` 和 `CGameLogic.h` 中，将函数 `IsExsit` 更正为 `IsExist`。